### PR TITLE
Webrtc support mingw build changes

### DIFF
--- a/3rdparty/webrtc-audio-processing-build/webrtc-audio-processing-build.pro
+++ b/3rdparty/webrtc-audio-processing-build/webrtc-audio-processing-build.pro
@@ -12,6 +12,7 @@ unix {
 win32 {
     !exists($$PWD/../webrtc-audio-processing-src/webrtc/modules/audio_processing/.libs/libwebrtc_audio_processing.a) {
         system("cd $$PWD/../webrtc-audio-processing-src && ./autogen.sh && \
+                export PATH=$PATH:/usr/lib/mxe/usr/bin && \
                 export CC=x86_64-w64-mingw32.static-gcc && \
                 export CXX=x86_64-w64-mingw32.static-g++ && \
                 export CPP=x86_64-w64-mingw32.static-cpp && \
@@ -26,7 +27,7 @@ win32 {
     }
 }
 
-TEMPLATE =aux 
+TEMPLATE =aux
 OBJECTS_DIR = ./
 DESTDIR = ./
 
@@ -34,4 +35,3 @@ macx {
     message("No support for webrtc-audio-processing on macx or win32 yet.")
     error("Aborting configuration")
 }
-

--- a/3rdparty/webrtc-audio-processing-build/webrtc-audio-processing-build.pro
+++ b/3rdparty/webrtc-audio-processing-build/webrtc-audio-processing-build.pro
@@ -9,11 +9,28 @@ unix {
     }
 }
 
+win32 {
+    !exists($$PWD/../webrtc-audio-processing-src/webrtc/modules/audio_processing/.libs/libwebrtc_audio_processing.a) {
+        system("cd $$PWD/../webrtc-audio-processing-src && ./autogen.sh && \
+                export CC=x86_64-w64-mingw32.static-gcc && \
+                export CXX=x86_64-w64-mingw32.static-g++ && \
+                export CPP=x86_64-w64-mingw32.static-cpp && \
+                export RANLIB=x86_64-w64-mingw32.static-ranlib && \
+                ./configure --host=x86_64-w64-mingw32 && \
+                make clean && make")
+    }
+
+    !exists($$PWD/../webrtc-audio-processing-src/webrtc/modules/audio_processing/.libs/libwebrtc_audio_processing.a) {
+        message("Cannot build 3rdparty/webrtc-audio-processing-src. Please fix.")
+        error("Aborting configuration.")
+    }
+}
+
 TEMPLATE =aux 
 OBJECTS_DIR = ./
 DESTDIR = ./
 
-macx|win32 {
+macx {
     message("No support for webrtc-audio-processing on macx or win32 yet.")
     error("Aborting configuration")
 }

--- a/3rdparty/webrtc-audio-processing-build/webrtc-audio-processing-build.pro
+++ b/3rdparty/webrtc-audio-processing-build/webrtc-audio-processing-build.pro
@@ -32,6 +32,6 @@ OBJECTS_DIR = ./
 DESTDIR = ./
 
 macx {
-    message("No support for webrtc-audio-processing on macx or win32 yet.")
+    message("No support for webrtc-audio-processing on macx yet.")
     error("Aborting configuration")
 }

--- a/README.md
+++ b/README.md
@@ -1,69 +1,54 @@
-Mumble - A voicechat utility for gamers
-=======================================
+Webrtc Mumble fork with echo cancelation
+===================================================
 
-> *http://mumble.info/*  
-> *#mumble on freenode*
+## Building for Windows
 
-Mumble is a voicechat program for gamers written on top of Qt and Opus.
+Only cross compilation with mingw tested and supported.
 
-There are two modules in Mumble; the client (mumble) and the server
-(murmur). The client works on Win32/64, Linux and Mac OS X, while the
-server should work on anything Qt can be installed on.
+Make sure you have the latest webrtc-audio-processing sources from either
+https://github.com/rakete/webrtc-audio-processing
+or
+https://github.com/hennakin/webrtc-audio-processing
+in 3rdparty/webrtc-audio-processing-src submodule path.
 
-Note that when we say Win32, we mean Windows XP or newer.
+# Installing the required MXE packages
 
-Goal of this fork is to implement a persistent chatlog and webrtc echo-cancellation and noise reduction.
+From https://wiki.mumble.info/wiki/BuildingWindows#Build_using_MXE_on_Debian_and_derivates
 
-## Running Mumble
+    echo "deb http://pkg.mxe.cc/repos/apt/debian jessie main" > /etc/apt/sources.list.d/mxeapt.list
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+    apt-get update
 
-On Windows, after installation, you should have a new Mumble folder in your
-Start Menu, from which you can start Mumble.
+Install the required packages
 
-On Mac OS X, to install Mumble, drag the application from the downloaded
-disk image into your `/Applications` folder.
+    apt-get install \
+        mxe-${ARCH}-w64-mingw32.static-qtbase \
+        mxe-${ARCH}-w64-mingw32.static-qtsvg \
+        mxe-${ARCH}-w64-mingw32.static-qttools \
+        mxe-${ARCH}-w64-mingw32.static-qttranslations \
+        mxe-${ARCH}-w64-mingw32.static-boost \
+        mxe-${ARCH}-w64-mingw32.static-protobuf \
+        mxe-${ARCH}-w64-mingw32.static-sqlite \
+        mxe-${ARCH}-w64-mingw32.static-flac \
+        mxe-${ARCH}-w64-mingw32.static-ogg \
+        mxe-${ARCH}-w64-mingw32.static-vorbis \
+        mxe-${ARCH}-w64-mingw32.static-libsndfile
 
-Once Mumble is launched, you need a server to connect to. Either create your
-own or join a friend's.
+# Building
 
-## Running Murmur on Unix-like systems
+Clone the repository from either rakete or hennakin
 
-Murmur should be run from the command line, so start a shell (command prompt)
-and go to wherever you installed Mumble. Run murmur as
+    git clone https://github.com/rakete/mumble.git # or https://github.com/hennakin/mumble.git
+    cd mumble
 
-```
-murmurd [-supw <password>] [-ini <inifile>] [-fg] [v]
+Export environment variable to tell QMake where MXE's protobuf compiler is and add MXE's directory to PATH
 
--supw   Set new password for the user SuperUser, which is hardcoded to
-        bypass ACLs. Keep this password safe. Until you set a password,
-        the SuperUser is disabled. If you use this option, murmur will
-        set the password in the database and then exit.
+    export MUMBLE_PROTOC=/usr/lib/mxe/usr/x86_64-unknown-linux-gnu/bin/protoc
+    export PATH=$PATH:/usr/lib/mxe/usr/bin
 
--ini    Use a inifile other than murmur.ini, use this to run several instances
-        of murmur from the same directory. Make sure each instance is using
-        a separate database.
+Run QMake to process the project(s) files and run make to start the build
 
--fg     Run in the foreground, logging to standard output.
+    x86_64-w64-mingw32.static-qmake-qt5 -recursive CONFIG+="release g15-emulator no-overlay no-bonjour no-elevation no-ice"
+    make
 
--v      More verbose logging.
-```
-
-## Running Murmur on Mac OS X
-
-Murmur is distributed seperately from the Mumble client on Mac OS X.
-It is called Static OS X Server and can be downloaded from the main webpage.
-
-Once downloaded it can be run in the same way as on any other Unix-like system.
-For more information please see the 'Running Murmur on Unix-like systems' above.
-
-## Running Murmur on Win32
-
-Doubleclick the Murmur icon to start murmur. There will be a small icon on your
-taskbar from which you can view the log.
-
-To set the superuser password, run murmur with the parameters `-supw <password>`.
-
-## Bandwidth usage
-
-Mumble will use 10-40 kbit/s outgoing, and the same incoming for each user.
-So if there are 10 other users on the server with you, your incoming
-bandwidth requirement will be 100-400 kbit/s if they all talk at the same time.
+Afterwards the windows build can be found in the mumble/release directory.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Webrtc Mumble fork with echo cancelation
 ===================================================
 
-## Building for Windows
+# Building for Windows
 
 Only cross compilation with mingw tested and supported.
 
@@ -11,7 +11,7 @@ or
 https://github.com/hennakin/webrtc-audio-processing
 in 3rdparty/webrtc-audio-processing-src submodule path.
 
-# Installing the required MXE packages
+## Installing the required MXE packages
 
 From https://wiki.mumble.info/wiki/BuildingWindows#Build_using_MXE_on_Debian_and_derivates
 
@@ -34,7 +34,7 @@ Install the required packages
         mxe-${ARCH}-w64-mingw32.static-vorbis \
         mxe-${ARCH}-w64-mingw32.static-libsndfile
 
-# Building
+## Building
 
 Clone the repository from either rakete or hennakin
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -434,6 +434,14 @@ win32 {
       QMAKE_POST_LINK = $$QMAKE_POST_LINK$$escape_expand(\\n\\t)$$quote(mt.exe -nologo -updateresource:$(DESTDIR_TARGET);1 -manifest mumble.appcompat.manifest)
     }
   }
+
+  !CONFIG(no-webrtc) {
+    QMAKE_CFLAGS *= -DWEBRTC_AUDIO_PROCESSING_ONLY_BUILD -DWEBRTC_WIN -I../../3rdparty/webrtc-audio-processing-src/
+    QMAKE_CXXFLAGS *= -DWEBRTC_AUDIO_PROCESSING_ONLY_BUILD -DWEBRTC_WIN -I../../3rdparty/webrtc-audio-processing-src/
+    QMAKE_CXXFLAGS_RELEASE *= -DWEBRTC_AUDIO_PROCESSING_ONLY_BUILD -DWEBRTC_WIN -I../../3rdparty/webrtc-audio-processing-src/
+    QMAKE_CXXFLAGS_DEBUG *= -DWEBRTC_AUDIO_PROCESSING_ONLY_BUILD -DWEBRTC_WIN -I../../3rdparty/webrtc-audio-processing-src/
+    LIBS += ../../3rdparty/webrtc-audio-processing-src/webrtc/modules/audio_processing/.libs/libwebrtc_audio_processing.a
+  }
 }
 
 unix {


### PR DESCRIPTION
Needs latest submodule webrtc-audio-processing from my repository https://github.com/rakete/webrtc-audio-processing

Changes to make mumble build with mingw toolchain on ubuntu 16.04.
I also put instructions how to build into README.md.